### PR TITLE
Fix Sharpy build steps in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Parallel and distributed execution currently is MPI/CSP-like. In a later version
 
 ## Setting up build environment
 
-Install MLIR/LLVM and Intel® Extension for MLIR (IMEX, see https://github.com/intel/mlir-extensions).
+Install MLIR/LLVM and Intel® Extension for MLIR (IMEX, see https://github.com/intel/mlir-extensions). Besides, Add "-DLLVM_ENABLE_RTTI=ON" into cmake arguments, and build target is "all" (not "check-imex").
 
 ```bash
 git clone --recurse-submodules https://github.com/IntelPython/sharded-array-for-python

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Parallel and distributed execution currently is MPI/CSP-like. In a later version
 
 ## Setting up build environment
 
-Install MLIR/LLVM and Intel® Extension for MLIR (IMEX, see https://github.com/intel/mlir-extensions). Besides, Add `-DLLVM_ENABLE_RTTI=ON` into cmake arguments, and build target is `all` (not `check-imex`).
+Install MLIR/LLVM and Intel® Extension for MLIR (IMEX, see https://github.com/intel/mlir-extensions). Make sure you use `-DLLVM_ENABLE_RTTI=ON` when configuring LLVM and use build target `all`.
 
 ```bash
 git clone --recurse-submodules https://github.com/IntelPython/sharded-array-for-python

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Install MLIR/LLVM and Intel® Extension for MLIR (IMEX, see https://github.com/i
 ```bash
 git clone --recurse-submodules https://github.com/IntelPython/sharded-array-for-python
 cd sharded-array-for-python
-git checkout jit
 conda create --file conda-env.txt --name sharpy
 conda activate sharpy
 export MPIROOT=$CONDA_PREFIX

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Parallel and distributed execution currently is MPI/CSP-like. In a later version
 
 ## Setting up build environment
 
-Install MLIR/LLVM and Intel® Extension for MLIR (IMEX, see https://github.com/intel/mlir-extensions). Besides, Add "-DLLVM_ENABLE_RTTI=ON" into cmake arguments, and build target is "all" (not "check-imex").
+Install MLIR/LLVM and Intel® Extension for MLIR (IMEX, see https://github.com/intel/mlir-extensions). Besides, Add `-DLLVM_ENABLE_RTTI=ON` into cmake arguments, and build target is `all` (not `check-imex`).
 
 ```bash
 git clone --recurse-submodules https://github.com/IntelPython/sharded-array-for-python


### PR DESCRIPTION
- Remove `git checkout jit`
- Added a tip for building imex (need to add `-DLLVM_ENABLE_RTTI=ON` into cmake arguments)

fix #6 